### PR TITLE
Wrap openai-node as a Python module using Pyodide FFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,3 +764,39 @@ If you are interested in other runtime environments, please open or upvote an is
 ## Contributing
 
 See [the contributing documentation](./CONTRIBUTING.md).
+
+## Using the Python Module with Pyodide
+
+To use the wrapped `openai-node` module as a Python module with Pyodide, follow these steps:
+
+1. Initialize Pyodide and load the `openai-node` module:
+
+```python
+import pyodide
+import js
+
+async def initialize_pyodide():
+    await pyodide.loadPackage('openai-node')
+    js.openai = js.require('openai')
+
+await initialize_pyodide()
+```
+
+2. Create an OpenAI client and use it to make API calls:
+
+```python
+def create_openai_client(api_key):
+    return js.openai(api_key)
+
+async def create_completion(client, prompt):
+    completion = await client.completions.create({
+        'model': 'text-davinci-003',
+        'prompt': prompt,
+        'max_tokens': 100
+    })
+    return completion.choices[0].text
+
+client = create_openai_client('your-api-key')
+result = await create_completion(client, 'Say this is a test')
+print(result)
+```

--- a/examples/pyodide_example.py
+++ b/examples/pyodide_example.py
@@ -1,0 +1,25 @@
+import pyodide
+import js
+
+async def initialize_pyodide():
+    await pyodide.loadPackage('openai-node')
+    js.openai = js.require('openai')
+
+def create_openai_client(api_key):
+    return js.openai(api_key)
+
+async def create_completion(client, prompt):
+    completion = await client.completions.create({
+        'model': 'text-davinci-003',
+        'prompt': prompt,
+        'max_tokens': 100
+    })
+    return completion.choices[0].text
+
+async def main():
+    await initialize_pyodide()
+    client = create_openai_client('your-api-key')
+    result = await create_completion(client, 'Say this is a test')
+    print(result)
+
+await main()

--- a/pyodide_wrapper.py
+++ b/pyodide_wrapper.py
@@ -1,0 +1,17 @@
+import pyodide
+import js
+
+async def initialize_pyodide():
+    await pyodide.loadPackage('openai-node')
+    js.openai = js.require('openai')
+
+def create_openai_client(api_key):
+    return js.openai(api_key)
+
+async def create_completion(client, prompt):
+    completion = await client.completions.create({
+        'model': 'text-davinci-003',
+        'prompt': prompt,
+        'max_tokens': 100
+    })
+    return completion.choices[0].text


### PR DESCRIPTION
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MRYingLEE/openai-node/pull/3?shareId=002dd338-cb35-4793-b00a-7d12ce66150d).

## Summary by Sourcery

Wrap the `openai-node` package as a Python module usable with Pyodide.

New Features:
- Enable using the `openai-node` library in a Python environment with Pyodide.

Tests:
- Add a usage example of the Pyodide wrapper.